### PR TITLE
Additional functions for projection and transformation

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -16,6 +16,7 @@ import ol.event.MapMoveListener;
 import ol.event.MapZoomListener;
 import ol.event.OLHandlerRegistration;
 import ol.event.TileLoadErrorListener;
+import ol.geom.Geometry;
 import ol.gwt.CollectionWrapper;
 import ol.layer.Base;
 import ol.layer.Layer;
@@ -184,6 +185,16 @@ public final class OLUtil {
     }
 
     /**
+     * Registers transformation functions that don't alter coordinates. Those allow
+     * to transform between projections with equal meaning.
+     *
+     * @param projections Projections.
+     */
+    public static native void addEquivalentProjections(Projection[] projections) /*-{
+		$wnd.ol.proj.addEquivalentProjections(projections);
+    }-*/;
+    
+    /**
      * Add a Projection object to the list of supported projections that can be
      * looked up by their code.
      *
@@ -296,6 +307,33 @@ public final class OLUtil {
     }-*/;
 
     /**
+     * Checks if two projections are the same, that is every coordinate in one
+     * projection does represent the same geographic point as the same
+     * coordinate in the other projection. (Taken from proj.js source of
+     * 'ol.proj.equivalent' as it is not part of the official API but still
+     * useful for identifying equal projections).
+     *
+     * @param projection1
+     *            Projection 1.
+     * @param projection2
+     *            Projection 2.
+     * @return {boolean} Equivalent.
+     */
+    public static native boolean equivalent(ol.proj.Projection projection1, ol.proj.Projection projection2) /*-{
+      if (projection1 === projection2) {
+        return true;
+      }
+      var equalUnits = projection1.getUnits() === projection2.getUnits();
+      if (projection1.getCode() === projection2.getCode()) {
+        return equalUnits;
+      } else {
+        var transformFn = ol.proj.getTransformFromProjections(
+            projection1, projection2);
+        return transformFn === ol.proj.cloneTransform && equalUnits;
+      }
+    }-*/;
+    
+    /**
      * Gets the geometry layout string for the given dimension.
      *
      * @param dim
@@ -398,7 +436,7 @@ public final class OLUtil {
         }
         return -1;
     }
-
+    
     /**
      * Gets the minimum zoomlevel of the given layer.
      *
@@ -637,6 +675,28 @@ public final class OLUtil {
 		return $wnd.ol.proj.transform(coordinate, source, destination);
     }-*/;
 
+    /**
+     * Transform each coordinate of the geometry from one coordinate reference
+     * system to another. The geometry is modified in place. For example, a line
+     * will be transformed to a line and a circle to a circle. If you do not
+     * want the geometry modified in place, first clone() it and then use this
+     * function on the clone.
+     *
+     * @param geom {@link Geometry}
+     *
+     * @param source
+     *            The current projection. Can be a string identifier or a
+     *            {@link ol.proj.Projection} object.
+     * @param destination
+     *            The desired projection. Can be a string identifier or a
+     *            {@link ol.proj.Projection} object.
+     * @return {@link Geometry} This geometry. Note that original geometry is
+     *         modified in place.
+     */
+    public static native Geometry transform(Geometry geom, Projection source, Projection destination) /*-{
+		return geom.transform(source, destination);
+    }-*/;
+    
     /**
      * Transforms a coordinate from source projection to destination projection.
      * This returns a new coordinate (and does not modify the original).

--- a/gwt-ol3-client/src/main/java/ol/proj/Projection.java
+++ b/gwt-ol3-client/src/main/java/ol/proj/Projection.java
@@ -30,17 +30,115 @@ import ol.Extent;
  */
 @JsType(prototype = "ol.proj.Projection")
 public interface Projection {
+    /**
+     * Projection unit 'degrees'.
+     */
+    static final String UNIT_DEGREES = "degrees";
+    /**
+     * Projection unit 'feet'.
+     */
+    static final String FEET = "ft";
+    /**
+     * Projection unit 'meters'.
+     */
+    static final String METERS = "m";
+    /**
+     * Projection unit 'pixels'.
+     */
+    static final String PIXELS = "pixels";
+    /**
+     * Projection unit 'tile pixels'.
+     */
+    static final String TILE_PIXELS = "tile-pixels";
+    /**
+     * Projection unit 'US feet'.
+     */
+    static final String USFEET = "'us-ft";
 
+    /**
+     * Get the code for this projection, e.g. 'EPSG:4326'.
+     * 
+     * @return {string} Code.
+     */
     String getCode();
 
+    /**
+     * Get the validity extent for this projection.
+     * 
+     * @return {ol.Extent} Extent.
+     */
     Extent getExtent();
 
+    /**
+     * Get the amount of meters per unit of this projection. If the projection
+     * is not configured with `metersPerUnit` or a units identifier, the return
+     * is `undefined`.
+     * 
+     * @return {number|undefined} Meters.
+     */
     double getMetersPerUnit();
 
+    /**
+     * Get the resolution of the point in degrees or distance units. For
+     * projections with degrees as the unit this will simply return the provided
+     * resolution. The default for other projections is to estimate the point
+     * resolution by transforming the 'point' pixel to EPSG:4326, measuring its
+     * width and height on the normal sphere, and taking the average of the
+     * width and height. An alternative implementation may be given when
+     * constructing a projection. For many local projections, such a custom
+     * function will return the resolution unchanged.
+     * 
+     * @param resolution
+     *            Resolution in projection units.
+     * @param point
+     *            Point.
+     * @return {number} Point resolution in projection units.
+     */
+    double getPointResolution(double resolution, ol.Coordinate point);
+
+    /**
+     * Get the units of this projection.
+     * 
+     * @return {ol.proj.Units} Units.
+     */
     String getUnits();
 
+    /**
+     * Get the world extent for this projection.
+     * 
+     * @return {ol.Extent} Extent.
+     */
+    Extent getWorldExtent();
+
+    /**
+     * Is this projection a global projection which spans the whole world?
+     * 
+     * @return {boolean} Whether the projection is global.
+     */
     boolean isGlobal();
 
+    /**
+     * Set if the projection is a global projection which spans the whole world
+     * 
+     * @param global
+     *            Whether the projection is global.
+     */
+    void setGlobal(boolean global);
+
+    /**
+     * Set the validity extent for this projection.
+     * 
+     * @param extent
+     *            Extent.
+     */
     void setExtent(Extent extent);
+
+    /**
+     * Set the world extent for this projection.
+     * 
+     * @param worldExtent
+     *            World extent [minlon, minlat, maxlon, maxlat].
+     */
+    void setWorldExtent(Extent worldExtent);
 
 }

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
Additional functions for projection and transformation, version bump.
`transform` for Geometry is like transform function in Geometry, but takes a `Projection` instance instead of string for the source/destination coordinate systems.
This allows caching projection instances and it might be safer to first get a projection instance and check it to be not null to ensure it actually exists.