### PR TITLE
support setting a style consisting of an array of styles

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -618,6 +618,39 @@ public final class OLUtil {
     }
 
     /**
+     * Set the style for the feature. This can be a single style object, an
+     * array of styles, or a function that takes a resolution and returns an
+     * array of styles. If it is `null` the feature has no style (a `null`
+     * style).
+     * 
+     * @param f
+     *            {@link ol.Feature}
+     * @param style
+     *            Style for this feature.
+     */
+    public static native void setStyle(ol.Feature f, @Nullable ol.style.Style[] style) /*-{
+        f.setStyle(style);
+    }-*/;
+
+    /**
+     * Set the style for features. This can be a single style object, an array
+     * of styles, or a function that takes a feature and resolution and returns
+     * an array of styles. If it is `undefined` the default style is used. If it
+     * is `null` the layer has no style (a `null` style), so only features that
+     * have their own styles will be rendered in the layer. See {@link ol.style}
+     * for information on the default style.
+     * 
+     * @param l
+     *            Layer
+     * @param style
+     *            Layer style.
+     */
+    public static native void setStyle(ol.layer.Vector l, @Nullable ol.style.Style[] style) /*-{
+        l.setStyle(style);
+    }-*/;
+
+    
+    /**
      * Transforms a coordinate from source projection to destination projection.
      * This returns a new coordinate (and does not modify the original).
      *

--- a/gwt-ol3-client/src/main/java/ol/layer/Vector.java
+++ b/gwt-ol3-client/src/main/java/ol/layer/Vector.java
@@ -3,6 +3,10 @@ package ol.layer;
 import com.google.gwt.core.client.js.JsType;
 
 /**
+ * Vector data that is rendered client-side. Note that any property set in the
+ * options is set as a {@link ol.Object} property on the layer object; for
+ * example, setting `title: 'My Title'` in the options means that `title` is
+ * observable, and has get/set accessors.
  * 
  * @author Tino Desjardins
  *
@@ -10,6 +14,26 @@ import com.google.gwt.core.client.js.JsType;
 @JsType(prototype = "ol.layer.Vector")
 public interface Vector extends Layer {
 
+    /**
+     * Get the style for features. This returns whatever was passed to the
+     * `style` option at construction or to the `setStyle` method.
+     * 
+     * @return {ol.style.Style|Array.<ol.style.Style>|ol.style.StyleFunction}
+     *         Layer style.
+     */
+    ol.style.Style getStyle();
+
+    /**
+     * Set the style for features. This can be a single style object, an array
+     * of styles, or a function that takes a feature and resolution and returns
+     * an array of styles. If it is `undefined` the default style is used. If it
+     * is `null` the layer has no style (a `null` style), so only features that
+     * have their own styles will be rendered in the layer. See {@link ol.style}
+     * for information on the default style.
+     * 
+     * @param style
+     *            Layer style.
+     */
+    void setStyle(ol.style.Style style);
 
 }
-


### PR DESCRIPTION
Support setting a style consisting of an array of styles, e.g. for providing point and polygon styles at the same time for a vector layer.

The style to set can be created by using `OlUtil.combineStyles()`.
By supplying a `null` value, the style can be removed from a feature or vector layer.