### PR TITLE
Projection fix

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -309,9 +309,10 @@ public final class OLUtil {
     /**
      * Checks if two projections are the same, that is every coordinate in one
      * projection does represent the same geographic point as the same
-     * coordinate in the other projection. (Taken from proj.js source of
-     * 'ol.proj.equivalent' as it is not part of the official API but still
-     * useful for identifying equal projections).
+     * coordinate in the other projection. The source code was taken from
+     * proj.js source of 'ol.proj.equivalent' as it is not part of the official
+     * API but still useful for identifying equal projections. It was only
+     * modified to not use non-public APIs.
      *
      * @param projection1
      *            Projection 1.
@@ -327,9 +328,9 @@ public final class OLUtil {
       if (projection1.getCode() === projection2.getCode()) {
         return equalUnits;
       } else {
-        var transformFn = ol.proj.getTransformFromProjections(
-            projection1, projection2);
-        return transformFn === ol.proj.cloneTransform && equalUnits;
+        var transformFn = $wnd.ol.proj.getTransform(projection1, projection2);
+        var transformFn2 = $wnd.ol.proj.getTransform(projection2, projection1);
+        return transformFn === transformFn2 && equalUnits;
       }
     }-*/;
     

--- a/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
+++ b/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
@@ -1,6 +1,8 @@
 package ol.event;
 
+import ol.OLUtil;
 import ol.geom.Geometry;
+import ol.proj.Projection;
 
 /**
  * An event for measuring.
@@ -9,20 +11,21 @@ import ol.geom.Geometry;
  */
 public class MeasureEvent {
 
-    /**
-     * Map projection code.
-     */
-    private static final String MAP_PROJECTION = "EPSG:3857";
     private final Geometry geom;
+    private final Projection projGeom;
 
     /**
      * Constructs an instance.
+     * 
+     * @param projGeom
+     *            {@link Projection} of the geometry
      *
      * @param geom
      *            measure {@link Geometry}
      */
-    public MeasureEvent(Geometry geom) {
+    public MeasureEvent(Projection projGeom, Geometry geom) {
         super();
+        this.projGeom = projGeom;
         this.geom = geom;
     }
 
@@ -34,19 +37,19 @@ public class MeasureEvent {
      * @return measure on success, else {@link Double#NaN}
      */
     private static double getMeasure(ol.geom.Geometry geom) {
-        if (geom instanceof ol.geom.LineString) {
-            ol.geom.LineString ls = (ol.geom.LineString) geom;
+        if(geom instanceof ol.geom.LineString) {
+            ol.geom.LineString ls = (ol.geom.LineString)geom;
             return ls.getLength();
-        } else if (geom instanceof ol.geom.Polygon) {
-            ol.geom.Polygon poly = (ol.geom.Polygon) geom;
+        } else if(geom instanceof ol.geom.Polygon) {
+            ol.geom.Polygon poly = (ol.geom.Polygon)geom;
             return poly.getArea();
         }
         return Double.NaN;
     }
 
     /**
-     * Gets the measurement geometry: a {@link LineString} for length
-     * measurements and a {@link Polygon} for area measurements.
+     * Gets the measurement geometry: a {@link ol.geom.LineString} for length
+     * measurements and a {@link ol.geom.Polygon} for area measurements.
      * 
      * @return {@link Geometry}
      */
@@ -71,8 +74,29 @@ public class MeasureEvent {
      * @return measure on success, else {@link Double#NaN}
      */
     public double getMeasure(String proj) {
-        Geometry geom = this.geom.clone().transform(MAP_PROJECTION, proj);
+        Geometry geom = this.geom.clone().transform(this.projGeom.getCode(), proj);
         return getMeasure(geom);
+    }
+
+    /**
+     * Gets the current measure in the given projection (and its unit).
+     *
+     * @param proj
+     *            projection
+     * @return measure on success, else {@link Double#NaN}
+     */
+    public double getMeasure(Projection proj) {
+        Geometry geom = OLUtil.transform(this.geom.clone(), this.projGeom, proj);
+        return getMeasure(geom);
+    }
+
+    /**
+     * Gets the {@link Projection} of the geometry.
+     * 
+     * @return {@link Projection}
+     */
+    public Projection getProjection() {
+        return this.projGeom;
     }
 
 }

--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -14,6 +14,7 @@ import ol.interaction.Draw;
 import ol.interaction.DrawEvent;
 import ol.interaction.DrawOptions;
 import ol.layer.VectorLayerOptions;
+import ol.proj.Projection;
 import ol.style.Style;
 
 /**
@@ -30,6 +31,7 @@ public class Measure {
     private MeasureListener listener;
     private final Map map;
     private ol.layer.Vector persistOverlay;
+    private Projection proj;
     private Feature sketch;
     private Style style;
 
@@ -51,7 +53,7 @@ public class Measure {
         if(isActive && (sketch != null) && (listener != null)) {
             Geometry geom = sketch.getGeometry();
             if(geom != null) {
-                listener.onMeasure(new MeasureEvent(geom));
+                listener.onMeasure(new MeasureEvent(proj, geom));
             }
         }
     }
@@ -137,6 +139,9 @@ public class Measure {
             persistOverlay = OLFactory.createVector(voptions);
             persistOverlay.setMap(map);
         }
+
+        // set up projection to be used
+        proj = map.getView().getProjection();
 
         map.addInteraction(draw);
         // set up event handlers
@@ -261,6 +266,7 @@ public class Measure {
         // clean up
         listener = null;
         sketch = null;
+        proj = null;
         // clean up interaction
         if(draw != null) {
             map.removeInteraction(draw);

--- a/gwt-ol3-client/src/main/java/ol/proj/Projection.java
+++ b/gwt-ol3-client/src/main/java/ol/proj/Projection.java
@@ -37,23 +37,23 @@ public interface Projection {
     /**
      * Projection unit 'feet'.
      */
-    static final String FEET = "ft";
+    static final String UNIT_FEET = "ft";
     /**
      * Projection unit 'meters'.
      */
-    static final String METERS = "m";
+    static final String UNIT_METERS = "m";
     /**
      * Projection unit 'pixels'.
      */
-    static final String PIXELS = "pixels";
+    static final String UNIT_PIXELS = "pixels";
     /**
      * Projection unit 'tile pixels'.
      */
-    static final String TILE_PIXELS = "tile-pixels";
+    static final String UNIT_TILE_PIXELS = "tile-pixels";
     /**
      * Projection unit 'US feet'.
      */
-    static final String USFEET = "'us-ft";
+    static final String UNIT_USFEET = "'us-ft";
 
     /**
      * Get the code for this projection, e.g. 'EPSG:4326'.

--- a/gwt-ol3-client/src/test/java/ol/proj/ProjectionTest.java
+++ b/gwt-ol3-client/src/test/java/ol/proj/ProjectionTest.java
@@ -52,7 +52,15 @@ public class ProjectionTest extends BaseTestCase {
         assertNotNull(projectionToCompare);
         
         assertEquals(projection.getCode(), projectionToCompare.getCode());
-        
+	assertTrue(OLUtil.equivalent(projection, projectionToCompare));
+    }
+    
+    public void testEquivalent() {
+	Projection p1 = OLUtil.getProjection(EPSG_CODE_4326);
+	Projection p2 = OLUtil.getProjection(EPSG_CODE_4326);
+	Projection p3 = OLUtil.getProjection(EPSG_CODE_3857);
+	assertTrue(OLUtil.equivalent(p1, p2));
+	assertFalse(OLUtil.equivalent(p1, p3));
     }
     
     public void testGet() {


### PR DESCRIPTION
Fix for comparing projections:
Change code taken from `proj.js` to match GWT specifics (use `$wnd.` prefix).
Remove private function calls used in original code: `getTransformFromProjections` can be replaced by `getTransform`, which is public.
Added tests to check this functionality.

Provide the currently used projection for the geometry in the `MeasureEvent`.
This allows to change the map view projection while still getting correct measurements.
The sample for measuring is still valid, the fix just ensures the measured geometry is returned using the correct transformation if the map view has a projection different than the default one.

*I even think of moving more towards http://openlayers.org/en/v3.13.0/examples/measure.html for the measuring functionality, but that is out of scope for this pull request.
Nevertheless it may make sense later on to enforce measuring of the geometry in WGS84 and then return the measured length/area in meters/kilometers.*