### PR TITLE
Fix for casting to JavaScriptObject throwing an exception

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -141,7 +141,7 @@ public final class OLUtil {
                             @Override
                             public void onEvent(ObjectEvent event) {
                                 // create an artificial move event
-                                Event e2 = createLinkedEvent(event, "move", (JavaScriptObject)map);
+                                Event e2 = createLinkedEvent(event, "move", map);
                                 MapEvent me = initMapEvent(e2, map);
                                 listener.onMapMove(me);
                             }
@@ -176,7 +176,7 @@ public final class OLUtil {
             @Override
             public void onEvent(ObjectEvent event) {
                 if("resolution".equals(event.getKey())) {
-                    Event e2 = createLinkedEvent(event, "zoom", (JavaScriptObject)map);
+                    Event e2 = createLinkedEvent(event, "zoom", map);
                     MapEvent me = initMapEvent(e2, map);
                     listener.onMapZoom(me);
                 }
@@ -289,8 +289,12 @@ public final class OLUtil {
      * @param currentTarget
      *            current target of the child event
      * @return child {@link Event} (gets its methods linked to the parent event)
+     * @param <T>
+     *            type of the event
+     * @param <U>
+     *            type of the target
      */
-    public static native Event createLinkedEvent(Event eParent, String type, JavaScriptObject currentTarget) /*-{
+    public static native <T extends Event, U> T createLinkedEvent(T eParent, String type, U currentTarget) /*-{
 		var eChild = {};
 		eChild.preventDefault = function() {
 			eParent.preventDefault();
@@ -430,7 +434,7 @@ public final class OLUtil {
         Source source = layer.get("source");
         if(source != null) {
             // try to get a tilegrid from the source
-            TileGrid tg = getTileGrid((JavaScriptObject)source);
+            TileGrid tg = getTileGrid(source);
             if(tg != null) {
                 return tg.getMaxZoom();
             }
@@ -450,7 +454,7 @@ public final class OLUtil {
         Source source = layer.get("source");
         if(source != null) {
             // try to get a tilegrid from the source
-            TileGrid tg = getTileGrid((JavaScriptObject)source);
+            TileGrid tg = getTileGrid(source);
             if(tg != null) {
                 return tg.getMinZoom();
             }
@@ -487,10 +491,10 @@ public final class OLUtil {
      * Gets a {@link TileGrid} from the given object, if the property is set
      *
      * @param o
-     *            {@link JavaScriptObject}
+     *            {@link ol.source.Source}
      * @return {@link TileGrid} on success, else null
      */
-    private static native TileGrid getTileGrid(JavaScriptObject o) /*-{
+    private static native TileGrid getTileGrid(ol.source.Source o) /*-{
 		return o.tileGrid || null;
     }-*/;
 
@@ -528,7 +532,7 @@ public final class OLUtil {
             Source source = l.get("source");
             if(source != null) {
                 // try to get a tilegrid from the source
-                TileGrid tg = getTileGrid((JavaScriptObject)source);
+                TileGrid tg = getTileGrid(source);
                 if(tg != null) {
                     // check resolutions
                     double[] resolutions = tg.getResolutions();

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.7</version>
+    <version>1.0.8</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.7</version>
+  <version>1.0.8</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
Fix for casting to `JavaScriptObject` throwing an exception:
in compiled/release mode on GWT 2.7.0 an exception is thrown while trying to cast a `@JsType` annotated class to `JavaScriptObject`,
in more detail the function call `com_google_gwt_lang_Cast_throwClassCastExceptionUnlessNull__Ljava_lang_Object_2Ljava_lang_Object_2` is compiled in before the actual call by GWT, which will throw an exception on any non-null object.
The fix avoids this behavior using generics.