### PR TITLE
Rework of measurements and add ol.Sphere

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.0.9</version>
+  <version>1.1.0</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLFactory.java
+++ b/gwt-ol3-client/src/main/java/ol/OLFactory.java
@@ -900,6 +900,17 @@ public final class OLFactory {
     	return [ width, height ];
     }-*/;
 
+    /**
+     * Creates a {@link Sphere}.
+     * @param radius
+     *            Radius.
+     *
+     * @return {@link Sphere}
+     */
+    public static native Sphere createSphere(double radius) /*-{
+        return new $wnd.ol.Sphere(radius);
+    }-*/;
+
     /** Common **/
 
     public static native Stamen createStamenSource(StamenOptions stamenOptions) /*-{

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -18,6 +18,7 @@ import ol.event.OLHandlerRegistration;
 import ol.event.TileLoadErrorListener;
 import ol.geom.Geometry;
 import ol.geom.Polygon;
+import ol.geom.SimpleGeometryMultiCoordinates;
 import ol.gwt.CollectionWrapper;
 import ol.layer.Base;
 import ol.layer.Layer;
@@ -598,6 +599,50 @@ public final class OLUtil {
             }
         }
         return -1;
+    }
+
+    /**
+     * Returns the geodesic area in square meters of the given geometry using
+     * the haversine formula.
+     *
+     * @param geom
+     *            geometry.
+     * @return geodesic area on success, else {@link Double#NaN}
+     */
+    public static double geodesicArea(Polygon geom) {
+        // get coordinates and check that there are at least 2
+        Coordinate[] coordinates = geom.getCoordinates();
+        if((coordinates != null) && (coordinates.length > 1)) {
+            Sphere sphere = createSphereNormal();
+            // only return positive area
+            return Math.abs(sphere.geodesicArea(coordinates));
+        }
+        return Double.NaN;
+    }
+
+    /**
+     * Returns the geodesic length in meters of the given geometry using the
+     * haversine formula.
+     *
+     * @param geom
+     *            geometry.
+     * @return geodesic length on success, else {@link Double#NaN}
+     */
+    public static double geodesicLength(SimpleGeometryMultiCoordinates geom) {
+        // get coordinates and check that there are at least 2
+        Coordinate[] coordinates = geom.getCoordinates();
+        if((coordinates != null) && (coordinates.length > 1)) {
+            // calculate the distance on every segment of the line and add it up
+            Sphere sphere = createSphereNormal();
+            double distance = 0;
+            for(int i = 0; i <= coordinates.length - 2; i++) {
+                Coordinate c1 = coordinates[i];
+                Coordinate c2 = coordinates[i + 1];
+                distance += sphere.haversineDistance(c1, c2);
+            }
+            return distance;
+        }
+        return Double.NaN;
     }
 
     /**

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -17,6 +17,7 @@ import ol.event.MapZoomListener;
 import ol.event.OLHandlerRegistration;
 import ol.event.TileLoadErrorListener;
 import ol.geom.Geometry;
+import ol.geom.Polygon;
 import ol.gwt.CollectionWrapper;
 import ol.layer.Base;
 import ol.layer.Layer;
@@ -37,8 +38,6 @@ import ol.tilegrid.TileGridOptions;
  */
 @ParametersAreNonnullByDefault
 public final class OLUtil {
-
-    private static final double EARTH_RADIUS = 6378137;
 
     // prevent instantiating this class
     @Deprecated
@@ -253,6 +252,24 @@ public final class OLUtil {
     }
 
     /**
+     * Create an approximation of a circle on the surface of a sphere.
+     * @param sphere
+     *            The sphere.
+     * @param center
+     *            Center (`[lon, lat]` in degrees).
+     * @param radius
+     *            The great-circle distance from the center to the polygon
+     *            vertices.
+     * @param opt_n
+     *            Optional number of vertices for the resulting polygon. Default
+     *            is `32`.
+     * @return {ol.geom.Polygon} The "circular" polygon.
+     */
+    public static native Polygon circular(Sphere sphere, ol.Coordinate center, double radius, int opt_n) /*-{
+        return $wnd.ol.geom.Polygon.circular(sphere, center, radius, opt_n);
+    }-*/;
+
+    /**
      * Combines two {@link Style}s into an array of {@link Style}s.
      *
      * @param s1
@@ -310,6 +327,24 @@ public final class OLUtil {
 		return eChild;
     }-*/;
 
+    /**
+     * Creates a sphere with radius equal to the semi-major axis of the WGS84
+     * ellipsoid.
+     * @return {@link Sphere}
+     */
+    public static Sphere createSphereWGS84() {
+        return OLFactory.createSphere(Sphere.EARTH_RADIUS_WGS84);
+    }
+
+    /**
+     * Creates a sphere with radius equal to the semi-major axis of the normal
+     * ellipsoid.
+     * @return {@link Sphere}
+     */
+    public static Sphere createSphereNormal() {
+        return OLFactory.createSphere(Sphere.EARTH_RADIUS_NORMAL);
+    }
+    
     /**
      * Checks if two projections are the same, that is every coordinate in one
      * projection does represent the same geographic point as the same
@@ -386,7 +421,7 @@ public final class OLUtil {
      * @return ground resolution
      */
     public static double getGroundResolutionInMeters(double latitude, int zoomLevel) {
-        return Math.cos(latitude * Math.PI / 180) * 2 * Math.PI * EARTH_RADIUS / getMapSizeInPixels(zoomLevel);
+        return Math.cos(latitude * Math.PI / 180) * 2 * Math.PI * ol.Sphere.EARTH_RADIUS_WGS84 / getMapSizeInPixels(zoomLevel);
     }
 
     /**
@@ -486,7 +521,7 @@ public final class OLUtil {
     public static native Projection getProjection(String projectionCode) /*-{
 		return $wnd.ol.proj.get(projectionCode);
     }-*/;
-
+    
     /**
      * Gets a {@link TileGrid} from the given object, if the property is set
      *

--- a/gwt-ol3-client/src/main/java/ol/Sphere.java
+++ b/gwt-ol3-client/src/main/java/ol/Sphere.java
@@ -1,0 +1,57 @@
+package ol;
+
+import com.google.gwt.core.client.js.JsType;
+
+/**
+ * Class to create objects that can be used with
+ * {@link ol.geom.Polygon.circular}.
+ *
+ * For example to create a sphere whose radius is equal to the semi-major axis
+ * of the WGS84 ellipsoid:
+ *
+ * ```js var wgs84Sphere= new ol.Sphere(6378137); ```
+ * @author sbaumhekel
+ *
+ */
+@JsType(prototype = "ol.Sphere")
+public interface Sphere {
+
+    /**
+     * Radius equal to the semi-major axis of the normal ellipsoid (like
+     * ol.sphere.NORMAL).
+     */
+    static final double EARTH_RADIUS_NORMAL = 6370997;
+
+    /**
+     * Radius equal to the semi-major axis of the WGS84 ellipsoid (like
+     * ol.sphere.WGS84).
+     */
+    static final double EARTH_RADIUS_WGS84 = 6378137;
+
+    /**
+     * Returns the geodesic area for a list of coordinates.
+     *
+     * [Reference](http://trs-new.jpl.nasa.gov/dspace/handle/2014/40409) Robert.
+     * G. Chamberlain and William H. Duquette, "Some Algorithms for Polygons on
+     * a Sphere", JPL Publication 07-03, Jet Propulsion Laboratory, Pasadena,
+     * CA, June 2007
+     *
+     * @param coordinates
+     *            List of coordinates of a linear ring. If the ring is oriented
+     *            clockwise, the area will be positive, otherwise it will be
+     *            negative.
+     * @return {number} Area.
+     */
+    double geodesicArea(ol.Coordinate[] coordinates);
+
+    /**
+     * Returns the distance from c1 to c2 using the haversine formula.
+     *
+     * @param c1
+     *            Coordinate 1.
+     * @param c2
+     *            Coordinate 2.
+     * @return {number} Haversine distance.
+     */
+    double haversineDistance(ol.Coordinate c1, ol.Coordinate c2);
+}

--- a/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
+++ b/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
@@ -5,52 +5,31 @@ import ol.geom.Geometry;
 import ol.proj.Projection;
 
 /**
- * An event for measuring.
+ * An event for measuring. It provides the measurment (length or area) directly
+ * as well as the underlying geometry in (WGS84 coordinates).
  *
  * @author sbaumhekel
  */
 public class MeasureEvent {
 
     private final Geometry geom;
-    private final Projection projGeom;
 
     /**
      * Constructs an instance.
-     * 
-     * @param projGeom
-     *            {@link Projection} of the geometry
+     *
      *
      * @param geom
-     *            measure {@link Geometry}
+     *            measure {@link Geometry} (in WGS84 geographic coordinates
+     *            (EPSG:4326))
      */
-    public MeasureEvent(Projection projGeom, Geometry geom) {
-        super();
-        this.projGeom = projGeom;
+    public MeasureEvent(Geometry geom) {
         this.geom = geom;
-    }
-
-    /**
-     * Gets the measure for the given {@link Geometry}.
-     *
-     * @param geom
-     *            measure {@link Geometry}
-     * @return measure on success, else {@link Double#NaN}
-     */
-    private static double getMeasure(ol.geom.Geometry geom) {
-        if(geom instanceof ol.geom.LineString) {
-            ol.geom.LineString ls = (ol.geom.LineString)geom;
-            return ls.getLength();
-        } else if(geom instanceof ol.geom.Polygon) {
-            ol.geom.Polygon poly = (ol.geom.Polygon)geom;
-            return poly.getArea();
-        }
-        return Double.NaN;
     }
 
     /**
      * Gets the measurement geometry: a {@link ol.geom.LineString} for length
      * measurements and a {@link ol.geom.Polygon} for area measurements.
-     * 
+     *
      * @return {@link Geometry}
      */
     public Geometry getGeometry() {
@@ -58,12 +37,17 @@ public class MeasureEvent {
     }
 
     /**
-     * Gets the current measure.
+     * Gets the current measure (length in meters or area in square meters).
      *
      * @return measure on success, else {@link Double#NaN}
      */
     public double getMeasure() {
-        return getMeasure(geom);
+        if(geom instanceof ol.geom.LineString) {
+            return OLUtil.geodesicLength((ol.geom.LineString)geom);
+        } else if(geom instanceof ol.geom.Polygon) {
+            return OLUtil.geodesicArea((ol.geom.Polygon)geom);
+        }
+        return Double.NaN;
     }
 
     /**
@@ -72,31 +56,37 @@ public class MeasureEvent {
      * @param proj
      *            projection
      * @return measure on success, else {@link Double#NaN}
+     * @deprecated use {@link #getMeasure()} instead
      */
-    public double getMeasure(String proj) {
-        Geometry geom = this.geom.clone().transform(this.projGeom.getCode(), proj);
-        return getMeasure(geom);
-    }
-
-    /**
-     * Gets the current measure in the given projection (and its unit).
-     *
-     * @param proj
-     *            projection
-     * @return measure on success, else {@link Double#NaN}
-     */
+    @Deprecated
     public double getMeasure(Projection proj) {
-        Geometry geom = OLUtil.transform(this.geom.clone(), this.projGeom, proj);
-        return getMeasure(geom);
+        return getMeasure();
+    }
+
+    /**
+     * Gets the current measure in the given projection (and its unit).
+     *
+     * @param proj
+     *            projection
+     * @return measure on success, else {@link Double#NaN}
+     * @deprecated use {@link #getMeasure()} instead
+     */
+    @Deprecated
+    public double getMeasure(String proj) {
+        return getMeasure();
     }
 
     /**
      * Gets the {@link Projection} of the geometry.
-     * 
+     *
      * @return {@link Projection}
+     * @deprecated the projection is always WGS84 geographic coordinates
+     *             (EPSG:4326)
      */
+    @SuppressWarnings("static-method")
+    @Deprecated
     public Projection getProjection() {
-        return this.projGeom;
+        return ol.OLUtil.getProjection("EPSG:4326");
     }
 
 }

--- a/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
+++ b/gwt-ol3-client/src/main/java/ol/gwt/Measure.java
@@ -24,6 +24,10 @@ import ol.style.Style;
  */
 public class Measure {
 
+    /**
+     * Projection for WGS84 geographic coordinates (EPSG:4326).
+     */
+    private static final Projection PROJECTION_LATLON = ol.OLUtil.getProjection("EPSG:4326");
     private com.google.gwt.user.client.EventListener chainedListener;
     private Draw draw;
     private boolean eventListenerNeedsCleanup;
@@ -51,9 +55,12 @@ public class Measure {
     private void fireMeasureEvent() {
         // check if measuring is active and properly set up
         if(isActive && (sketch != null) && (listener != null)) {
+            // get geometry in map projection
             Geometry geom = sketch.getGeometry();
             if(geom != null) {
-                listener.onMeasure(new MeasureEvent(proj, geom));
+                // transform it to lat/lon and fire event
+                Geometry geomLatLon = OLUtil.transform(geom.clone(), proj, PROJECTION_LATLON);
+                listener.onMeasure(new MeasureEvent(geomLatLon));
             }
         }
     }

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.0.9</version>
+    <version>1.1.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.0.9</version>
+  <version>1.1.0</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/gwt-ol3-demo/src/main/java/de/desjardins/ol3/demo/client/example/MeasureExample.java
+++ b/gwt-ol3-demo/src/main/java/de/desjardins/ol3/demo/client/example/MeasureExample.java
@@ -81,7 +81,7 @@ public class MeasureExample implements Example {
 			@Override
 			public void onMeasure(MeasureEvent evt) {
 				// log the measured length
-				GWT.log("measure: " + evt.getMeasure() + " Lat/Lon: " + evt.getMeasure("EPSG:4326"));
+				GWT.log("measure: " + evt.getMeasure());
 			}
 
 		}, true, true);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.9</version>
+  <version>1.1.0</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
**Rework of measurements**

Now always meters (for lengths) or square meters (for areas) are returned and the geometry is always returned in lat/lon coordinates. Furthermore the lengths and areas are calculated geodesic, which adjusts
for the underlying sphere/geoid.

The sample has been changed accordingly.

The deprecated functions in MeasureEvent might be removed later on.
They just affect getting measurements using a different projection, which does not make anymore sense.

**Add ol.Sphere and supporting functions.**

The constants for the earth radius are unfortunately not public in the current API of OpenLayers 3 (see https://github.com/openlayers/ol3/issues/4954).

With this change the functions for calculating a geodesic area and distance will become usable for example to increase accuracy in measurements.