### PR TITLE
Fix for wrong coordinate format used for polygons

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLFactory.java
+++ b/gwt-ol3-client/src/main/java/ol/OLFactory.java
@@ -826,7 +826,7 @@ public final class OLFactory {
      *            coordinates
      * @return {@link Polygon}
      */
-    public static native Polygon createPolygon(Coordinate[] coordinates) /*-{
+    public static native Polygon createPolygon(Coordinate[][] coordinates) /*-{
     	return new $wnd.ol.geom.Polygon(coordinates);
     }-*/;
 
@@ -839,7 +839,7 @@ public final class OLFactory {
      *            geometry layout
      * @return {@link Polygon}
      */
-    public static native Polygon createPolygon(@Nullable Coordinate[] coordinates, @Nullable String geometryLayout) /*-{
+    public static native Polygon createPolygon(@Nullable Coordinate[][] coordinates, @Nullable String geometryLayout) /*-{
     	return new $wnd.ol.geom.Polygon(coordinates, geometryLayout);
     }-*/;
 

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -18,6 +18,7 @@ import ol.event.OLHandlerRegistration;
 import ol.event.TileLoadErrorListener;
 import ol.geom.Geometry;
 import ol.geom.Polygon;
+import ol.geom.SimpleGeometryCoordinates;
 import ol.geom.SimpleGeometryMultiCoordinates;
 import ol.gwt.CollectionWrapper;
 import ol.layer.Base;
@@ -611,7 +612,33 @@ public final class OLUtil {
      */
     public static double geodesicArea(Polygon geom) {
         // get coordinates and check that there are at least 2
-        Coordinate[] coordinates = geom.getCoordinates();
+        Coordinate[][] coordinates = geom.getCoordinates();
+        if((coordinates != null) && (coordinates.length > 0)) {
+            // get area of outer ring
+            double area = geodesicArea(coordinates[0]);
+            // walk through inner rings
+            for(int i = 1; i < coordinates.length; i++) {
+                // if area is valid, subtract it from the outer ring's area
+                double holeArea = geodesicArea(coordinates[i]);
+                if(!Double.isNaN(holeArea)) {
+                    area -= holeArea;
+                }
+            }
+            return area;
+        }
+        return Double.NaN;
+    }
+
+    /**
+     * Returns the geodesic area in square meters of the given geometry using
+     * the haversine formula.
+     *
+     * @param coordinates
+     *            coordinates.
+     * @return geodesic area on success, else {@link Double#NaN}
+     */
+    private static double geodesicArea(Coordinate[] coordinates) {
+        // check that there are at least 2
         if((coordinates != null) && (coordinates.length > 1)) {
             Sphere sphere = createSphereNormal();
             // only return positive area
@@ -628,7 +655,7 @@ public final class OLUtil {
      *            geometry.
      * @return geodesic length on success, else {@link Double#NaN}
      */
-    public static double geodesicLength(SimpleGeometryMultiCoordinates geom) {
+    public static double geodesicLength(SimpleGeometryCoordinates geom) {
         // get coordinates and check that there are at least 2
         Coordinate[] coordinates = geom.getCoordinates();
         if((coordinates != null) && (coordinates.length > 1)) {

--- a/gwt-ol3-client/src/main/java/ol/geom/Circle.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/Circle.java
@@ -10,7 +10,7 @@ import ol.Coordinate;
  * @author sbaumhekel
  */
 @JsType(prototype = "ol.geom.Circle")
-public interface Circle extends SimpleGeometryMultiCoordinates {
+public interface Circle extends SimpleGeometry {
     /**
      * Return the center of the circle as {@link ol.Coordinate coordinate}.
      * 

--- a/gwt-ol3-client/src/main/java/ol/geom/LineString.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/LineString.java
@@ -10,7 +10,7 @@ import ol.Coordinate;
  * @author sbaumhekel
  */
 @JsType(prototype="ol.geom.LineString")
-public interface LineString extends SimpleGeometryMultiCoordinates {
+public interface LineString extends SimpleGeometryCoordinates {
     /**
      * Append the passed coordinate to the coordinates of the linestring.
      *

--- a/gwt-ol3-client/src/main/java/ol/geom/LinearRing.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/LinearRing.java
@@ -8,7 +8,7 @@ import com.google.gwt.core.client.js.JsType;
  * @author sbaumhekel
  */
 @JsType(prototype = "ol.geom.LinearRing")
-public interface LinearRing extends SimpleGeometryMultiCoordinates {
+public interface LinearRing extends SimpleGeometryCoordinates {
     /**
      * Return the area of the linear ring on projected plane.
      * 

--- a/gwt-ol3-client/src/main/java/ol/geom/SimpleGeometryCoordinates.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/SimpleGeometryCoordinates.java
@@ -7,20 +7,20 @@ import com.google.gwt.core.client.js.JsType;
 import ol.Coordinate;
 
 /**
- * This is an additional class to provide an array of arrays of coordinates for
- * geometries and still allow {@link Point} to be a {@link SimpleGeometry}
- * though it only has one coordinate.
+ * This is an additional class to provide an array of coordinates for geometries
+ * and still allow {@link Point} to be a {@link SimpleGeometry} though it only
+ * has one coordinate.
  * 
  * @author sbaumhekel
  */
 @JsType
-public interface SimpleGeometryMultiCoordinates extends SimpleGeometry {
+public interface SimpleGeometryCoordinates extends SimpleGeometry {
     /**
      * Return the coordinates of this geometry.
      *
      * @return Coordinates.
      */
-    Coordinate[][] getCoordinates();
+    Coordinate[] getCoordinates();
 
     /**
      * Set the coordinates of this geometry.
@@ -30,6 +30,6 @@ public interface SimpleGeometryMultiCoordinates extends SimpleGeometry {
      * @param geometryLayout
      *            opt_layout Layout.
      */
-    void setCoordinates(Coordinate[][] coordinates, @Nullable String geometryLayout);
+    void setCoordinates(Coordinate[] coordinates, @Nullable String geometryLayout);
 
 }

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
Polygons use an array of an array of coordinates, because they store every ring in a separate array. The type was corrected and functions using it have been adapted.

Furthermore the type hierarchy was checked for all the geometries and corrected where necessary.