### PR TITLE
Add new functions in OpenLayers 3.15.0

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -8,7 +8,7 @@
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-client</artifactId>
   <name>${project.artifactId}</name>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
 
   <repositories>
     <repository>

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -349,10 +349,7 @@ public final class OLUtil {
     /**
      * Checks if two projections are the same, that is every coordinate in one
      * projection does represent the same geographic point as the same
-     * coordinate in the other projection. The source code was taken from
-     * proj.js source of 'ol.proj.equivalent' as it is not part of the official
-     * API but still useful for identifying equal projections. It was only
-     * modified to not use non-public APIs.
+     * coordinate in the other projection.
      *
      * @param projection1
      *            Projection 1.
@@ -361,17 +358,7 @@ public final class OLUtil {
      * @return {boolean} Equivalent.
      */
     public static native boolean equivalent(ol.proj.Projection projection1, ol.proj.Projection projection2) /*-{
-      if (projection1 === projection2) {
-        return true;
-      }
-      var equalUnits = projection1.getUnits() === projection2.getUnits();
-      if (projection1.getCode() === projection2.getCode()) {
-        return equalUnits;
-      } else {
-        var transformFn = $wnd.ol.proj.getTransform(projection1, projection2);
-        var transformFn2 = $wnd.ol.proj.getTransform(projection2, projection1);
-        return transformFn === transformFn2 && equalUnits;
-      }
+      return $wnd.ol.proj.equivalent(projection1, projection2);
     }-*/;
 
     /**

--- a/gwt-ol3-client/src/main/java/ol/geom/Geometry.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/Geometry.java
@@ -55,6 +55,16 @@ public interface Geometry extends Observable {
     String getType();
 
     /**
+     * Rotate the geometry around a given coordinate. This modifies the geometry
+     * coordinates in place.
+     * @param angle
+     *            Rotation angle in radians.
+     * @param anchor
+     *            The rotation center.
+     */
+    void rotate(double angle, Coordinate anchor);
+    
+    /**
      * Create a simplified version of this geometry. For linestrings, this uses
      * the the
      * <a href="https://en.wikipedia.org/wiki/Ramer-Douglas-Peucker_algorithm">

--- a/gwt-ol3-client/src/main/java/ol/source/Source.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Source.java
@@ -44,6 +44,11 @@ public interface Source extends ol.Object {
     String getState();
 
     /**
+     * Refreshes the source and finally dispatches a 'change' event.
+     */
+    void refresh();
+    
+    /**
      * Set the attributions of the source.
      * 
      * @param attributions

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,14 +6,14 @@
   <parent>
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>1.1.1</version>
+    <version>1.2.0</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
   <groupId>ol</groupId>
   <artifactId>gwt-ol3-demo</artifactId>
   <packaging>war</packaging>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <name>${project.artifactId}</name>
 
  <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>de.desjardins.ol3</groupId>
   <artifactId>gwt-ol3</artifactId>
   <packaging>pom</packaging>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <name>${project.artifactId}</name>
 
   <repositories>


### PR DESCRIPTION
_Source refresh and native equivalent_
Allow to refresh a source and reload its data (see pull request https://github.com/openlayers/ol3/pull/4868).

_ol.proj.equivalent_
The latest OpenLayers version exposes the ol.proj.equivalent function publicly
(see pull request https://github.com/openlayers/ol3/pull/4914).
So change OLUtil to use it directly.

_Add rotate_
add rotate to geometry (since OpenLayers 3.15.0).

_New version_
Version bump to 1.2.0 (to also indicate new OpenLayers 3 release).
