### PR TITLE
Add jitpack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ GWT-OpenLayers 3
 ==================
 
 [![Build Status](https://travis-ci.org/TDesjardins/gwt-ol3.svg?branch=gwt%2F2.8)](https://travis-ci.org/TDesjardins/gwt-ol3)
+[![Build Artifacts](https://jitpack.io/v/TDesjardins/gwt-ol3.svg)](https://jitpack.io/#TDesjardins/gwt-ol3)
 
 A [OpenLayers 3](http://openlayers.org/ "OpenLayers 3 website") - Wrapper for GWT using the new [JSInterop](https://docs.google.com/document/d/10fmlEYIHcyead_4R1S5wKGs1t2I7Fnp_PaNaa7XTEk0/edit)-Features of the [GWT-SDK 2.8.0](http://www.gwtproject.org/release-notes.html#Release_Notes_2_8_0_RC1 "Release notes"). The project consists of two parts:
   


### PR DESCRIPTION
Jitpack is a zero configuration artifact repository, it automatically build your github project if anyone references your project as a dependency, cool! Might be useful until you decide to go to central (using sonatype, bintray, etc).