### PR TITLE
Sonatype build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,29 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.sonatype.oss</groupId>
+        <artifactId>oss-parent</artifactId>
+        <version>9</version>
+    </parent>
+
     <groupId>de.desjardins.ol3</groupId>
     <artifactId>gwt-ol3</artifactId>
     <version>2.4.0</version>
     <packaging>pom</packaging>
+
+    <name>GWT OpenLayers 3</name>
+    <description>GWT JsInterop API for OpenLayers 3</description>
+    <url>https://github.com/TDesjardins/gwt-ol3</url>
+
+    <inceptionYear>2014</inceptionYear>
+    <licenses>
+        <license>
+            <name>Apache 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+    </licenses>
 
     <developers>
         <developer>
@@ -17,6 +36,29 @@
             </roles>
         </developer>
     </developers>
+
+    <scm>
+        <connection>scm:git:git://github.com/TDesjardins/gwt-ol3.git</connection>
+        <developerConnection>scm:git:git://github.com/TDesjardins/gwt-ol3.git</developerConnection>
+        <url>https://github.com/TDesjardins/gwt-ol3</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/TDesjardins/gwt-ol3/issues</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <site>
+            <id>github-ssh</id>
+            <url>gitsite:git@github.com/TDesjardins/gwt-ol3.git</url>
+        </site>
+    </distributionManagement>
+
+    <prerequisites>
+        <maven>3</maven>
+    </prerequisites>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -87,6 +129,23 @@
                         <url>gwtol3playground/GwtOL3Playground.html</url>
                     </startupUrls>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <version>3.4</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.stephenc.wagon</groupId>
+                        <artifactId>wagon-gitsite</artifactId>
+                        <version>0.5</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>2.8</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
I hope it's ok and nothing fail when you deploy 😉.

The scm.tag is wrong. Another personal idea; what do you think about using master for 2.8 and gwt2.7 for gwt 2.7 😛. If you makes the 2.8 the main branch (master) the scm.tag=HEAD is ok, but if you leave it at gwt/2.8 you need to set the tag correctly. Maybe HEAD will work for both, I'm not sure 😞 , you should confirm anyways.

The demo project make no much sense to be deployed in central, if you want to skip it to be deployed you can configure the maven deployer plugin like this https://github.com/intendia-oss/autorest-gwt/blob/master/example/pom.xml#L104.

And I added the distributionManagement.site, if you want to use it you need to initialize the github pages for this project, although the maven project web page is not very useful, maybe you prefer to deploy the demo directly in this project github pages, in this case just remove the distributionMaven.site section. 