### PR TITLE
Fix for OLUtil.observe and OLUtil.observeOnce

### DIFF
--- a/gwt-ol3-client/pom.xml
+++ b/gwt-ol3-client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.tdesjardins</groupId>
         <artifactId>gwt-ol3</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>gwt-ol3-client</artifactId>
     <packaging>gwt-lib</packaging>

--- a/gwt-ol3-client/src/main/java/ol/event/EventListener.java
+++ b/gwt-ol3-client/src/main/java/ol/event/EventListener.java
@@ -1,7 +1,5 @@
 package ol.event;
 
-import jsinterop.annotations.JsType;
-
 /**
  * A listener for events of the given type.
  * 
@@ -10,7 +8,6 @@ import jsinterop.annotations.JsType;
  * @param <E>
  *            event type
  */
-@JsType(isNative = true)
 public interface EventListener<E extends Event> {
 
     /**

--- a/gwt-ol3-demo/pom.xml
+++ b/gwt-ol3-demo/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.tdesjardins</groupId>
         <artifactId>gwt-ol3</artifactId>
-        <version>2.7.0</version>
+        <version>2.7.1</version>
     </parent>
     <artifactId>gwt-ol3-demo</artifactId>
     <packaging>gwt-app</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.github.tdesjardins</groupId>
     <artifactId>gwt-ol3</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.1</version>
     <packaging>pom</packaging>
 
     <name>GWT OpenLayers 3</name>


### PR DESCRIPTION
Fix for `OLUtil.observe` and `OLUtil.observeOnce` to prevent error with missing function `onEvent` in event handler.
Version bump.