### PR TITLE
Changes according to breaking changes in OpenLayers 4.0.0

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/EventsKey.java
+++ b/gwt-ol3-client/src/main/java/ol/EventsKey.java
@@ -1,0 +1,15 @@
+package ol;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Key to use with {@link ol.Observable#unByKey}.
+ *
+ * @author sbaumhekel
+ */
+public class EventsKey extends JavaScriptObject {
+
+    @Deprecated
+    protected EventsKey() {
+    }
+}

--- a/gwt-ol3-client/src/main/java/ol/OLFactory.java
+++ b/gwt-ol3-client/src/main/java/ol/OLFactory.java
@@ -1255,21 +1255,6 @@ public final class OLFactory {
         return new $wnd.ol.source.TileWMS(tileWmsOptions);
     }-*/;
 
-    /**
-     * Fetches a Projection object for the code specified.
-     *
-     * @param proj
-     *            Either a code string which is a combination of authority and
-     *            identifier such as "EPSG:4326", or an existing projection
-     *            object, or undefined.
-     * @return {@link ol.proj.Projection} Projection object, or null if not in list.
-     * @deprecated Use {@link ol.proj.Projection#get(String)} instead.
-     */
-    @Deprecated
-    public static Projection get(String proj) {
-        return Projection.get(proj);
-    }
-
     public static native JavaScriptObject createEventFunction(Executor t) /*-{
         return function (selectevent) {
             t.action(selectevent);

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -3,7 +3,6 @@ package ol;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
@@ -18,7 +17,6 @@ import ol.event.OLHandlerRegistration;
 import ol.event.TileLoadEndListener;
 import ol.event.TileLoadErrorListener;
 import ol.event.TileLoadStartListener;
-import ol.geom.Geometry;
 import ol.geom.Polygon;
 import ol.geom.SimpleGeometryCoordinates;
 import ol.gwt.CollectionWrapper;
@@ -179,31 +177,6 @@ public final class OLUtil {
     }
 
     /**
-     * Registers transformation functions that don't alter coordinates. Those allow
-     * to transform between projections with equal meaning.
-     *
-     * @param projections Projections.
-     * @deprecated Use {@link ol.proj.Projection#addEquivalentProjections(Projection[])} instead.
-     */
-    @Deprecated
-    public static void addEquivalentProjections(Projection[] projections) {
-		Projection.addEquivalentProjections(projections);
-    };
-
-    /**
-     * Add a Projection object to the list of supported projections that can be
-     * looked up by their code.
-     *
-     * @param projection
-     *            Projection instance.
-     * @deprecated Use {@link ol.proj.Projection#addProjection(Projection)} instead.
-     */
-    @Deprecated
-    public static void addProjection(Projection projection) {
-        Projection.addProjection(projection);
-    };
-
-    /**
      * Adds a {@link Style} to the given array of {@link Style}s.
      *
      * @param s
@@ -250,45 +223,45 @@ public final class OLUtil {
         });
     }
 
-	/**
-	 * Adds a listener for tile start loading.
-	 *
-	 * @param source
-	 *            source
-	 *
-	 * @param listener
-	 *            {@link TileLoadStartListener}
-	 * @return {@link HandlerRegistration}
-	 */
-	public static HandlerRegistration addTileLoadStartListener(UrlTile source, final TileLoadStartListener listener) {
-		return observe(source, "tileloadstart", new EventListener<Tile.Event>() {
+    /**
+     * Adds a listener for tile start loading.
+     *
+     * @param source
+     *            source
+     *
+     * @param listener
+     *            {@link TileLoadStartListener}
+     * @return {@link HandlerRegistration}
+     */
+    public static HandlerRegistration addTileLoadStartListener(UrlTile source, final TileLoadStartListener listener) {
+        return observe(source, "tileloadstart", new EventListener<Tile.Event>() {
 
-			@Override
-			public void onEvent(Tile.Event event) {
-				listener.onTileLoadStart(event);
-			}
-		});
-	}
+            @Override
+            public void onEvent(Tile.Event event) {
+                listener.onTileLoadStart(event);
+            }
+        });
+    }
 
-	/**
-	 * Adds a listener for tile end loading.
-	 *
-	 * @param source
-	 *            source
-	 *
-	 * @param listener
-	 *            {@link TileLoadEndListener}
-	 * @return {@link HandlerRegistration}
-	 */
-	public static HandlerRegistration addTileLoadEndListener(UrlTile source, final TileLoadEndListener listener) {
-		return observe(source, "tileloadend", new EventListener<Tile.Event>() {
+    /**
+     * Adds a listener for tile end loading.
+     *
+     * @param source
+     *            source
+     *
+     * @param listener
+     *            {@link TileLoadEndListener}
+     * @return {@link HandlerRegistration}
+     */
+    public static HandlerRegistration addTileLoadEndListener(UrlTile source, final TileLoadEndListener listener) {
+        return observe(source, "tileloadend", new EventListener<Tile.Event>() {
 
-			@Override
-			public void onEvent(Tile.Event event) {
-				listener.onTileLoadEnd(event);
-			}
-		});
-	}
+            @Override
+            public void onEvent(Tile.Event event) {
+                listener.onTileLoadEnd(event);
+            }
+        });
+    }
 
     /**
      * Create an approximation of a circle on the surface of a sphere.
@@ -321,20 +294,6 @@ public final class OLUtil {
 		return [ s1, s2 ];
     }-*/;
 
-    /**
-     * Creates a JavaScript function calling the given event listener.
-     *
-     * @param listener
-     *            listener
-     * @return JavaScript function
-     * @deprecated Use functional interfaces {@link jsinterop.annotations.JsFunction} instead.
-     */
-    @Deprecated
-    public static native <E extends Event> JavaScriptObject createEventListenerFunction(EventListener<E> listener) /*-{
-		return function(evt) {
-			listener.onEvent(evt);
-		};
-    }-*/;
 
     /**
      * Links to {@link Event}s by delegating the childs methods to the parents
@@ -385,23 +344,6 @@ public final class OLUtil {
     public static Sphere createSphereNormal() {
         return OLFactory.createSphere(EARTH_RADIUS_NORMAL);
     }
-
-    /**
-     * Checks if two projections are the same, that is every coordinate in one
-     * projection does represent the same geographic point as the same
-     * coordinate in the other projection.
-     *
-     * @param projection1
-     *            Projection 1.
-     * @param projection2
-     *            Projection 2.
-     * @return {boolean} Equivalent.
-     * @deprecated Use {@link ol.proj.Projection#equivalent(Projection, Projection)} instead.
-     */
-    @Deprecated
-    public static native boolean equivalent(ol.proj.Projection projection1, ol.proj.Projection projection2) /*-{
-      return $wnd.ol.proj.equivalent(projection1, projection2);
-    }-*/;
 
     /**
      * Gets the geometry layout string for the given dimension.
@@ -497,21 +439,6 @@ public final class OLUtil {
     @Nullable
     public static String getName(Base layer) {
         return layer.get("name");
-    }
-
-    /**
-     * Fetches a Projection object for the code specified.
-     *
-     * @param projectionCode
-     *            Either a code string which is a combination of authority and
-     *            identifier such as "EPSG:4326", or an existing projection
-     *            object, or undefined.
-     * @return {@link ol.proj.Projection} Projection object, or null if not in list.
-     * @deprecated Use {@link ol.proj.Projection#get(String)} instead.
-     */
-    @Deprecated
-    public static Projection getProjection(String projectionCode) {
-        return Projection.get(projectionCode);
     }
 
     /**
@@ -729,7 +656,7 @@ public final class OLUtil {
      */
     public static <E extends Event> HandlerRegistration observe(Observable o, String eventType,
             EventListener<E> listener) {
-        JavaScriptObject key = o.on(eventType, listener);
+        EventsKey key = o.on(eventType, listener);
         return new OLHandlerRegistration(o, key);
     }
 
@@ -747,7 +674,7 @@ public final class OLUtil {
      */
     public static <E extends Event> HandlerRegistration observeOnce(Observable o, String eventType,
             EventListener<E> listener) {
-        JavaScriptObject key = o.once(eventType, listener);
+        EventsKey key = o.once(eventType, listener);
         return new OLHandlerRegistration(o, key);
     }
 
@@ -809,74 +736,6 @@ public final class OLUtil {
 
 
     /**
-     * Transforms a coordinate from source projection to destination projection.
-     * This returns a new coordinate (and does not modify the original).
-     *
-     * See {@link #transformExtent(Extent, Projection, Projection)} for extent
-     * transformation. See the transform method of {@link ol.geom.Geometry} and
-     * its subclasses for geometry transforms.
-     *
-     * @param coordinate
-     *            Coordinate.
-     * @param source
-     *            Source projection-like.
-     * @param destination
-     *            Destination projection-like.
-     * @return {ol.Coordinate} Coordinate.
-     * @deprecated Use {@link ol.proj.Projection#transform(Coordinate, Projection, Projection)} instead.
-     */
-    @Deprecated
-    public static native Coordinate transform(Coordinate coordinate, Projection source, Projection destination) /*-{
-		return $wnd.ol.proj.transform(coordinate, source, destination);
-    }-*/;
-
-    /**
-     * Transform each coordinate of the geometry from one coordinate reference
-     * system to another. The geometry is modified in place. For example, a line
-     * will be transformed to a line and a circle to a circle. If you do not
-     * want the geometry modified in place, first clone() it and then use this
-     * function on the clone.
-     *
-     * @param geom {@link Geometry}
-     *
-     * @param source
-     *            The current projection. Can be a string identifier or a
-     *            {@link ol.proj.Projection} object.
-     * @param destination
-     *            The desired projection. Can be a string identifier or a
-     *            {@link ol.proj.Projection} object.
-     * @return {@link Geometry} This geometry. Note that original geometry is
-     *         modified in place.
-     * @deprecated Use {@link ol.geom.Geometry#transform(ol.proj.Projection, ol.proj.Projection)} instead.
-     */
-    @Deprecated
-    public static native Geometry transform(Geometry geom, Projection source, Projection destination) /*-{
-		return geom.transform(source, destination);
-    }-*/;
-
-    /**
-     * Transforms a coordinate from source projection to destination projection.
-     * This returns a new coordinate (and does not modify the original).
-     *
-     * See {@link #transformExtent(Extent, Projection, Projection)} for extent
-     * transformation. See the transform method of {@link ol.geom.Geometry} and
-     * its subclasses for geometry transforms.
-     *
-     * @param coordinate
-     *            Coordinate.
-     * @param source
-     *            Source projection-like.
-     * @param destination
-     *            Destination projection-like.
-     * @return {ol.Coordinate} Coordinate.
-     * @deprecated Use {@link ol.proj.Projection#transform(Coordinate, String, String)} instead.
-     */
-    @Deprecated
-    public static Coordinate transform(Coordinate coordinate, String source, String destination) {
-        return Projection.transform(coordinate, source, destination);
-    }
-
-    /**
      * Transforms coordinates from source projection to destination projection.
      * This returns new coordinates (and does not modify the original).
      *
@@ -898,41 +757,5 @@ public final class OLUtil {
 
         return transformedCoordinates;
     }
-
-    /**
-     * Transforms an extent from source projection to destination projection.
-     * This returns a new extent (and does not modify the original).
-     *
-     * @param extent
-     *            The extent to transform.
-     * @param source
-     *            Source projection-like.
-     * @param destination
-     *            Destination projection-like.
-     * @return {ol.Extent} The transformed extent.
-     * @deprecated Use {@link ol.proj.Projection#transformExtent(Extent, Projection, Projection)} instead.
-     */
-    @Deprecated
-    public static Extent transformExtent(Extent extent, Projection source, Projection destination) {
-		return Projection.transformExtent(extent, source, destination);
-    };
-
-    /**
-     * Transforms an extent from source projection to destination projection.
-     * This returns a new extent (and does not modify the original).
-     *
-     * @param extent
-     *            The extent to transform.
-     * @param source
-     *            Source projection-like.
-     * @param destination
-     *            Destination projection-like.
-     * @return {ol.Extent} The transformed extent.
-     * @deprecated Use {@link ol.proj.Projection#transformExtent(Extent, String, String)} instead.
-     */
-    @Deprecated
-    public static Extent transformExtent(Extent extent, String source, String destination) {
-		return Projection.transformExtent(extent, source, destination);
-    };
 
 }

--- a/gwt-ol3-client/src/main/java/ol/Observable.java
+++ b/gwt-ol3-client/src/main/java/ol/Observable.java
@@ -1,7 +1,5 @@
 package ol;
 
-import com.google.gwt.core.client.JavaScriptObject;
-
 import jsinterop.annotations.JsType;
 import ol.event.Event;
 import ol.event.EventListener;
@@ -32,7 +30,7 @@ public abstract class Observable {
      *            The listener function.
      * @return Unique key for the listener.
      */
-    public native JavaScriptObject on(String type, EventListener<? extends Event> listener);
+    public native EventsKey on(String type, EventListener<? extends Event> listener);
 
     /**
      * Listen once for a certain type of event.
@@ -43,7 +41,7 @@ public abstract class Observable {
      *            The listener function.
      * @return {goog.events.Key} Unique key for the listener.
      */
-    public native JavaScriptObject once(String type, EventListener<? extends Event> listener);
+    public native EventsKey once(String type, EventListener<? extends Event> listener);
 
     /**
      * Unlisten for a certain type of event.
@@ -57,11 +55,11 @@ public abstract class Observable {
     public native void un(String type, EventListener<? extends Event> listener);
 
     /**
-     * Removes an event listener using the key returned by on() or once(). Note
-     * that using the ol.Observable.unByKey static function is to be preferred.
-     *
+     * Removes an event listener using the key returned by on() or once(). *
      * @param key
-     *            The key returned by on() or once().
+     *            {ol.EventsKey|Array.<ol.EventsKey>} key The key returned by
+     *            `on()` or `once()` (or an array of keys).
      */
-    public native void unByKey(JavaScriptObject key);
+    public static native void unByKey(EventsKey key);
+
 }

--- a/gwt-ol3-client/src/main/java/ol/Sphere.java
+++ b/gwt-ol3-client/src/main/java/ol/Sphere.java
@@ -4,7 +4,7 @@ import jsinterop.annotations.JsType;
 
 /**
  * Class to create objects that can be used with
- * {@link ol.geom.Polygon.circular}.
+ * {@link ol.geom.Polygon#circular(Sphere, Coordinate, double, int)}.
  *
  * For example to create a sphere whose radius is equal to the semi-major axis
  * of the WGS84 ellipsoid:
@@ -16,7 +16,10 @@ import jsinterop.annotations.JsType;
 @JsType(isNative = true)
 public class Sphere {
 
-    
+    /**
+     * @param radius
+     *            Radius.
+     */
     public Sphere(double radius) {}
     
     /**

--- a/gwt-ol3-client/src/main/java/ol/View.java
+++ b/gwt-ol3-client/src/main/java/ol/View.java
@@ -80,10 +80,21 @@ public class View extends Object {
      *
      * @param geometry
      *            {ol.geom.SimpleGeometry|ol.Extent} Geometry.
-     * @param size
-     *            Box pixel size.
+     * @param opt_options
+     *            options
      */
-    public native void fit(TypedObject<ol.geom.SimpleGeometry, ol.Extent> geometry, Size size);
+    public native void fit(TypedObject<ol.geom.SimpleGeometry, ol.Extent> geometry, ViewFitOptions opt_options);
+
+    /**
+     * Fit the given geometry or extent based on the given map size and border.
+     * The size is pixel dimensions of the box to fit the extent into. In most
+     * cases you will want to use the map size, that is `map.getSize()`. Takes
+     * care of the map angle.
+     *
+     * @param geometry
+     *            {ol.geom.SimpleGeometry|ol.Extent} Geometry.
+     */
+    public native void fit(TypedObject<ol.geom.SimpleGeometry, ol.Extent> geometry);
 
     /**
      * Get the view center.

--- a/gwt-ol3-client/src/main/java/ol/ViewFitOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/ViewFitOptions.java
@@ -1,0 +1,61 @@
+package ol;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsProperty;
+import jsinterop.annotations.JsType;
+
+/**
+ * Options for calling {@link ol.View#fit(ol.gwt.TypedObject, ViewFitOptions)}.
+ *
+ * @author sbaumhekel
+ */
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class ViewFitOptions implements Options {
+
+    /**
+     * Constrain the resolution. Default is true.
+     * @param constrainResolution
+     */
+    @JsProperty
+    public native void setConstrainResolution(boolean constrainResolution);
+
+    /**
+     * The duration of the animation in milliseconds. By default, there is no
+     * animations.
+     * @param duration
+     */
+    @JsProperty
+    public native void setDuration(int duration);
+
+    /**
+     * Maximum zoom level that we zoom to. If minResolution is given, this
+     * property is ignored.
+     * @param maxZoom
+     */
+    @JsProperty
+    public native void setMaxZoom(double maxZoom);
+
+    /**
+     * Minimum resolution that we zoom to. Default is 0.
+     * @param minResolution
+     */
+    @JsProperty
+    public native void setMinResolution(double minResolution);
+
+    /**
+     * Get the nearest extent. Default is false.
+     * @param nearest
+     */
+    @JsProperty
+    public native void setNearest(boolean nearest);
+
+    /**
+     * The size in pixels of the box to fit the extent into. Default is the
+     * current size of the first map in the DOM that uses this view, or [100,
+     * 100] if no such map is found.
+     * @param size
+     */
+    @JsProperty
+    public native void setSize(ol.Size size);
+
+}

--- a/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
+++ b/gwt-ol3-client/src/main/java/ol/event/MeasureEvent.java
@@ -2,7 +2,6 @@ package ol.event;
 
 import ol.OLUtil;
 import ol.geom.Geometry;
-import ol.proj.Projection;
 
 /**
  * An event for measuring. It provides the measurment (length or area) directly
@@ -47,45 +46,6 @@ public class MeasureEvent {
             return OLUtil.geodesicArea((ol.geom.Polygon)geom);
         }
         return Double.NaN;
-    }
-
-    /**
-     * Gets the current measure in the given projection (and its unit).
-     *
-     * @param proj
-     *            projection
-     * @return measure on success, else {@link Double#NaN}
-     * @deprecated use {@link #getMeasure()} instead
-     */
-    @Deprecated
-    public double getMeasure(Projection proj) {
-        return getMeasure();
-    }
-
-    /**
-     * Gets the current measure in the given projection (and its unit).
-     *
-     * @param proj
-     *            projection
-     * @return measure on success, else {@link Double#NaN}
-     * @deprecated use {@link #getMeasure()} instead
-     */
-    @Deprecated
-    public double getMeasure(String proj) {
-        return getMeasure();
-    }
-
-    /**
-     * Gets the {@link Projection} of the geometry.
-     *
-     * @return {@link Projection}
-     * @deprecated the projection is always WGS84 geographic coordinates
-     *             (EPSG:4326)
-     */
-    @SuppressWarnings("static-method")
-    @Deprecated
-    public Projection getProjection() {
-        return ol.OLUtil.getProjection("EPSG:4326");
     }
 
 }

--- a/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
+++ b/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
@@ -1,8 +1,8 @@
 package ol.event;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.HandlerRegistration;
 
+import ol.EventsKey;
 import ol.Observable;
 
 /**
@@ -12,7 +12,7 @@ import ol.Observable;
  */
 public class OLHandlerRegistration implements HandlerRegistration {
 
-    private JavaScriptObject key;
+    private EventsKey key;
     private Observable o;
 
     /**
@@ -23,7 +23,7 @@ public class OLHandlerRegistration implements HandlerRegistration {
      * @param key
      *            key
      */
-    public OLHandlerRegistration(Observable o, JavaScriptObject key) {
+    public OLHandlerRegistration(Observable o, EventsKey key) {
         this.o = o;
         this.key = key;
     }
@@ -37,8 +37,8 @@ public class OLHandlerRegistration implements HandlerRegistration {
     @Override
     public void removeHandler() {
         // unregister handler and remove all references
-        if (o != null) {
-            o.unByKey(key);
+        if(o != null) {
+            Observable.unByKey(key);
             o = null;
             key = null;
         }

--- a/gwt-ol3-client/src/main/java/ol/geom/Polygon.java
+++ b/gwt-ol3-client/src/main/java/ol/geom/Polygon.java
@@ -11,6 +11,64 @@ import jsinterop.annotations.JsType;
 public class Polygon extends SimpleGeometryMultiCoordinates {
 
     /**
+     * Create an approximation of a circle on the surface of a sphere.
+     * @param sphere
+     *            The sphere.
+     * @param center
+     *            Center (`[lon, lat]` in degrees).
+     * @param radius
+     *            The great-circle distance from the center to the polygon
+     *            vertices.
+     * @return {ol.geom.Polygon} The "circular" polygon.
+     */
+    public static native Polygon circular(ol.Sphere sphere, ol.Coordinate center, double radius);
+
+    /**
+     * Create an approximation of a circle on the surface of a sphere.
+     * @param sphere
+     *            The sphere.
+     * @param center
+     *            Center (`[lon, lat]` in degrees).
+     * @param radius
+     *            The great-circle distance from the center to the polygon
+     *            vertices.
+     * @param opt_n
+     *            Optional number of vertices for the resulting polygon. Default
+     *            is `32`.
+     * @return {ol.geom.Polygon} The "circular" polygon.
+     */
+    public static native Polygon circular(ol.Sphere sphere, ol.Coordinate center, double radius, int opt_n);
+
+    /**
+     * Create a regular polygon from a circle.
+     * @param circle
+     *            Circle geometry.
+     * @return {ol.geom.Polygon} Polygon geometry.
+     */
+    public static native Polygon fromCircle(Circle circle);
+
+    /**
+     * Create a regular polygon from a circle.
+     * @param circle
+     *            Circle geometry.
+     * @param opt_sides
+     *            Number of sides of the polygon. Default is 32.
+     * @param opt_angle
+     *            Start angle for the first vertex of the polygon in radians.
+     *            Default is 0.
+     * @return {ol.geom.Polygon} Polygon geometry.
+     */
+    public static native Polygon fromCircle(Circle circle, int opt_sides, double opt_angle);
+
+    /**
+     * Create a polygon from an extent. The layout used is `XY`.
+     * @param extent
+     *            The extent.
+     * @return {ol.geom.Polygon} The polygon.
+     */
+    public static native Polygon fromExtent(ol.Extent extent);
+
+    /**
      * Append the passed linear ring to this polygon.
      *
      * @param linearRing
@@ -24,6 +82,13 @@ public class Polygon extends SimpleGeometryMultiCoordinates {
      * @return {number} Area (on projected plane).
      */
     public native double getArea();
+
+    /**
+     * Return an interior point of the polygon.
+     *
+     * @return {ol.geom.Point} Point.
+     */
+    public native Point getInteriorPoint();
 
     /**
      * Return the Nth linear ring of the polygon geometry. Return `null` if the
@@ -50,12 +115,5 @@ public class Polygon extends SimpleGeometryMultiCoordinates {
      * @return {Array.<ol.geom.LinearRing>} Linear rings.
      */
     public native LinearRing[] getLinearRings();
-
-    /**
-     * Return an interior point of the polygon.
-     *
-     * @return {ol.geom.Point} Point.
-     */
-    public native Point getInteriorPoint();
 
 }


### PR DESCRIPTION
Changes according to breaking changes in OpenLayers 4.0.0 at https://github.com/openlayers/openlayers/releases/tag/v4.0.0
Change `ol.View.fit` to reflect changes in OpenLayers.

Use `EventKey` for Observable event listeners. Does not break anything as it extends `JavaScriptObject`, which was used before - but allows type additional type checking.

Cleanup methods deprecated more than two releases ago.
This helps to clean up `OLUtil`, `OLFactory` and `MeasureEvent` and reduces the number of helper methods on top of the original OpenLayers code.