### PR TITLE
Edited GeoJSONFeatureOptions - added @JsProperty as I was getting "de…

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/format/GeoJSONFeatureOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/format/GeoJSONFeatureOptions.java
@@ -17,6 +17,7 @@ package ol.format;
 
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import jsinterop.annotations.JsProperty;
 import ol.Options;
 import ol.proj.Projection;
 
@@ -31,16 +32,19 @@ public class GeoJSONFeatureOptions implements Options {
     /**
      * @param projection
      */
+    @JsProperty
     public native void setDataProjection(Projection projection);
 
     /**
      * @param projection
      */
+    @JsProperty
     public native void setFeatureProjection(Projection projection);
 
     /**
      * @param rightHanded
      */
+    @JsProperty
     public native void setRightHanded(boolean rightHanded);
 
 }

--- a/gwt-ol3-client/src/main/java/ol/format/OSMXML.java
+++ b/gwt-ol3-client/src/main/java/ol/format/OSMXML.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright 2014, 2017 gwt-ol3
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package ol.format;
+
+import jsinterop.annotations.JsType;
+import ol.proj.Projection;
+import ol.Feature;
+import ol.Options;
+
+import javax.annotation.Nullable;
+/**
+ * OSMXML format
+ *
+ * @author Tino Desjardins
+ *
+ * @see http://openlayers.org/en/latest/apidoc/ol.format.OSMXML.html
+ */
+@JsType(isNative = true)
+public class OSMXML extends XMLFeature {
+
+	public OSMXML() {}
+    
+    public OSMXML(Options osmXMLOptions) {}
+
+
+	/**
+	 * Read all features from a GeoJSON source. Works with both Feature and FeatureCollection sources.
+	 * @param source Document | Node | Object | string
+	 * @param opt_options Read options.
+	 * @return [] {@link Feature}
+	 */
+	public native Feature[] readFeatures(java.lang.Object source, @Nullable Options opt_options);
+
+	/**
+	 * Read the projection from a GeoJSON source.
+	 * @param source Document | Node | Object | string
+	 * @return {@link Geometry}
+	 */
+	public native Projection readProjection(java.lang.Object source);
+    
+}

--- a/gwt-ol3-client/src/main/java/ol/format/OSMXMLFeatureOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/format/OSMXMLFeatureOptions.java
@@ -22,23 +22,29 @@ import ol.Options;
 import ol.proj.Projection;
 
 /**
- * Options for the GeoJSON
+ * Options for the OSMXML.
  *
  * @author tlochmann
  */
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
-public class GeoJSONOptions implements Options {
+public class OSMXMLFeatureOptions implements Options {
 
     /**
      * @param projection
      */
     @JsProperty
-    public native void setDefaultDataProjection(Projection projection);
+    public native void setDataProjection(Projection projection);
 
     /**
-     * @param geometryName
+     * @param projection
      */
     @JsProperty
-    public native void setGeometryName(String geometryName);
+    public native void setFeatureProjection(Projection projection);
+
+    /**
+     * @param rightHanded
+     */
+    @JsProperty
+    public native void setRightHanded(boolean rightHanded);
 
 }


### PR DESCRIPTION
…faultDataProjection is not a function"

Same for GeoJSONOptions.
Added OSMXML.java and OSMXMLFeatureOptions.java to use OSM file format downloaded from openstreetmaps.org directly.

I tried this at my code and it works:
OSMXMLFeatureOptions osmXMLOptions = OLFactory.createOptions();

ProjectionOptions dataProjection = OLFactory.createOptions();
dataProjection.setCode("EPSG:4326");

ProjectionOptions featureProjection = OLFactory.createOptions();
featureProjection.setCode("EPSG:3857");

osmXMLOptions.setDataProjection(OLFactory.createProjection(dataProjection));
osmXMLOptions.setFeatureProjection(OLFactory.createProjection(featureProjection));

OSMXML osmXMLFormat = new OSMXML();

//mapOSM is a String downloaded from openstreetmaps.org that I loaded from a file
Feature[] featuresOSM = osmXMLFormat.readFeatures(mapOSM, osmXMLOptions);