### PR TITLE
Improve MapZoomListener

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -177,11 +177,15 @@ public final class OLUtil {
      * @return {@link HandlerRegistration}
      */
     public static HandlerRegistration addMapZoomListener(final Map map, final MapZoomListener listener) {
-        return observe(map.getView(), "propertychange", new EventListener<ObjectEvent>() {
+        return observe(map, "moveend", new EventListener<ObjectEvent>() {
 
+	    private int zoomLevel = (int) map.getView().getZoom();
+		
             @Override
             public void onEvent(ObjectEvent event) {
-                if("resolution".equals(event.getKey())) {
+                int newZoomLevel = (int) map.getView().getZoom();
+                if(newZoomLevel != zoomLevel) {
+                    zoomLevel = newZoomLevel;
                     Event e2 = createLinkedEvent(event, "zoom", map);
                     MapEvent me = initMapEvent(e2, map);
                     listener.onMapZoom(me);


### PR DESCRIPTION
I wounder if this approach isn't a better way to filter for zoom events:
You listen to map's "moveend" which only triggers once on both zooming and paning. Then you check for zoomlevel changes.
(I'm not sure about the cast to int though. Just didn't want to compare doubles.)

In my opinion there are at least 2 reasons to not use the "propertychange"-event here:
1. The listener is called unessecarily, because on every zoom and pan this event is fired realy often.
2. Even though the filter on"resolution" actualy distincts panning events from zooming events, you never manage calling the registered zoom-listener only once, because "propertychange" is triggered so often and "resolution" never is the cause for it only once (this slowed down my application. I received like 10 events every time I zoomed).