### PR TITLE
TileLoad* related deprecations

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -16,6 +16,7 @@
 package ol;
 
 import javax.annotation.Nullable;
+
 import javax.annotation.ParametersAreNonnullByDefault;
 
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -255,7 +256,10 @@ public final class OLUtil {
      * @param listener
      *            {@link TileLoadErrorListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link ol.source.Tile#addTileLoadErrorListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addTileLoadErrorListener(UrlTile source, final TileLoadErrorListener listener) {
         return observe(source, "tileloaderror", new EventListener<Tile.Event>() {
 
@@ -275,7 +279,10 @@ public final class OLUtil {
      * @param listener
      *            {@link TileLoadStartListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link ol.source.Tile#addTileLoadStartListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addTileLoadStartListener(UrlTile source, final TileLoadStartListener listener) {
         return observe(source, "tileloadstart", new EventListener<Tile.Event>() {
 
@@ -295,7 +302,10 @@ public final class OLUtil {
      * @param listener
      *            {@link TileLoadEndListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link ol.source.Tile#addTileLoadEndListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addTileLoadEndListener(UrlTile source, final TileLoadEndListener listener) {
         return observe(source, "tileloadend", new EventListener<Tile.Event>() {
 

--- a/gwt-ol3-client/src/main/java/ol/event/TileLoadEndListener.java
+++ b/gwt-ol3-client/src/main/java/ol/event/TileLoadEndListener.java
@@ -20,7 +20,9 @@ import ol.source.Tile;
 /**
  * A listener for tile finishes loading.
  * 
+ * @deprecated Use {@link ol.source.Tile#addTileLoadEndListener(EventListener)}
  */
+@Deprecated
 public interface TileLoadEndListener {
 
 	/**

--- a/gwt-ol3-client/src/main/java/ol/event/TileLoadErrorListener.java
+++ b/gwt-ol3-client/src/main/java/ol/event/TileLoadErrorListener.java
@@ -22,7 +22,10 @@ import ol.source.Tile;
  * A listener for tile loading errors.
  * 
  * @author sbaumhekel
+ * 
+ * @deprecated Use {@link ol.source.Tile#addTileLoadErrorListener(EventListener)}
  */
+@Deprecated
 public interface TileLoadErrorListener {
 
     /**

--- a/gwt-ol3-client/src/main/java/ol/event/TileLoadStartListener.java
+++ b/gwt-ol3-client/src/main/java/ol/event/TileLoadStartListener.java
@@ -20,7 +20,9 @@ import ol.source.Tile;
 /**
  * A listener for tile starts loading.
  * 
+ * @deprecated Use {@link ol.source.Tile#addTileLoadStartListener(EventListener)}
  */
+@Deprecated
 public interface TileLoadStartListener {
 
 	/**


### PR DESCRIPTION
Deprecated specialized listeners and global/static event adding for three `TileLoad*` events in favor of methods in `ol.source.Tile`.