### PR TITLE
Support for line dash offset in ol.style.Stroke and ol.style.StrokeOptions

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/style/Stroke.java
+++ b/gwt-ol3-client/src/main/java/ol/style/Stroke.java
@@ -62,6 +62,13 @@ public interface Stroke {
     int[] getLineDash();
 
     /**
+     * Get the line dash offset for the stroke.
+     *
+     * @return Line dash offset.
+     */
+    int getLineDashOffset();
+
+    /**
      * Get the line join type for the stroke.
      *
      * @return
@@ -98,6 +105,13 @@ public interface Stroke {
      * @param value
      */
     void setLineDash(int[] value);
+
+    /**
+     * Set the line dash offset.
+     *
+     * @param lineDashOffset Line dash offset.
+     */
+    void setLineDashOffset(int lineDashOffset);
 
     /**
      * Set the line join.

--- a/gwt-ol3-client/src/main/java/ol/style/StrokeOptions.java
+++ b/gwt-ol3-client/src/main/java/ol/style/StrokeOptions.java
@@ -75,6 +75,14 @@ public class StrokeOptions implements Options {
     public native void setLineDash(int[] lineDash);
 
     /**
+     * Line dash offset. Default is <code>0</code>.
+     *
+     * @param lineDashOffset Offset.
+     */
+    @JsProperty
+    public native void setLineDashOffset(int lineDashOffset);
+
+    /**
      * Set the Miter limit. Default is 10.
      *
      * @param miterLimit


### PR DESCRIPTION
Caveat: GWT/JSInterop stuff works, I can see member variables set in JavaScript, but it seems this attribute is broken in OpenLayers.

Reported an issue here: https://github.com/openlayers/openlayers/issues/7040

Still, I believe this brings value to gwt-ol3, so this PR.