### PR TITLE
Refactored map events

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/Map.java
+++ b/gwt-ol3-client/src/main/java/ol/Map.java
@@ -448,7 +448,7 @@ public class Map extends Object {
 
         View view = getView();
         
-        if (view != null)
+        if (view == null)
         	return handlerMap;
 
     	// if we have a view, fire events while the map is moving

--- a/gwt-ol3-client/src/main/java/ol/Map.java
+++ b/gwt-ol3-client/src/main/java/ol/Map.java
@@ -22,7 +22,6 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;
 import jsinterop.annotations.JsType;
 import ol.control.Control;
-import ol.event.DoubleClickListener;
 import ol.event.EventListener;
 import ol.events.Event;
 import ol.interaction.Interaction;

--- a/gwt-ol3-client/src/main/java/ol/OLUtil.java
+++ b/gwt-ol3-client/src/main/java/ol/OLUtil.java
@@ -85,7 +85,10 @@ public final class OLUtil {
      * @param listener
      *            {@link ClickListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link Map#addClickListener(EventListener)} or {@link Map#addSingleClickListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addClickListener(Map map, boolean singleClicksOnly,
             final ClickListener listener) {
         String type;
@@ -111,7 +114,10 @@ public final class OLUtil {
      * @param listener
      *            {@link DoubleClickListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link Map#addDoubleClickListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addDoubleClickListener(Map map, final DoubleClickListener listener) {
         return observe(map, "dblclick", new EventListener<MapBrowserEvent>() {
 
@@ -130,7 +136,10 @@ public final class OLUtil {
      * @param listener
      *            {@link MapMoveListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link Map#addMapMoveListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addMapMoveListener(final Map map, final MapMoveListener listener) {
         // listen to "moveend" events of map
         final HandlerRegistration handlerMap = observe(map, "moveend", new EventListener<MapEvent>() {
@@ -176,7 +185,10 @@ public final class OLUtil {
      * @param listener
      *            {@link MapZoomListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link Map#addMapZoomListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addMapZoomListener(final Map map, final MapZoomListener listener) {
         return observe(map.getView(), "change:resolution", new EventListener<ObjectEvent>() {
 
@@ -197,7 +209,10 @@ public final class OLUtil {
      * @param listener
      *            {@link MapZoomListener}
      * @return {@link HandlerRegistration}
+     * 
+     * @deprecated Use {@link Map#addMapZoomEndListener(EventListener)}
      */
+    @Deprecated
     public static HandlerRegistration addMapZoomEndListener(final Map map, final MapZoomListener listener) {
         return observe(map, "moveend", new EventListener<ObjectEvent>() {
 
@@ -218,7 +233,6 @@ public final class OLUtil {
             }
         });
     }
-
 
     /**
      * Adds a {@link Style} to the given array of {@link Style}s.

--- a/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/MapEventsExample.java
+++ b/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/MapEventsExample.java
@@ -21,12 +21,10 @@ import com.google.gwt.user.client.Window;
 
 import ol.Coordinate;
 import ol.Map;
-import ol.MapBrowserEvent;
 import ol.MapOptions;
 import ol.OLFactory;
 import ol.View;
 import ol.control.Attribution;
-import ol.event.DoubleClickListener;
 import ol.interaction.DragPan;
 import ol.interaction.KeyboardPan;
 import ol.interaction.KeyboardZoom;
@@ -97,14 +95,7 @@ public class MapEventsExample implements Example {
         map.addInteraction(new MouseWheelZoom());
 
         // add event handlers
-        map.addDoubleClickListener(new DoubleClickListener() {
-
-            @Override
-            public void onDoubleClick(MapBrowserEvent evt) {
-                Window.alert("double click at " + evt.getCoordinate().getX() + ", " + evt.getCoordinate().getX());
-            }
-
-        });
+        map.addDoubleClickListener(evt -> Window.alert("double click at " + evt.getCoordinate().getX() + ", " + evt.getCoordinate().getX()));
 
     }
 


### PR DESCRIPTION
Copied Map events registrations from `OLUtils` to `ol.Map` and deprecated ones in `OLUtils`.

**Possible breaking change**: changed signature for `ol.Map::addDoubleClickListener`: parameter changed from `DoubleClickListener` to `EventListener<MapBrowserEvent>`. It won't break registrations made using closures or method references, but **will break** ones made with anonymous inner classes.

If that is not acceptable, I would suggest leaving (deprecated) add**Double**ClickListener that accepts `DoubleClickListener` and rename new one (that accepts `EventListener<MapBrowserEvent>`) to add**Dbl**ClickListener. That way closures could be passed to both methods.