### PR TITLE
Use the correct HandlerRegistration interface.

### DIFF
--- a/gwt-ol3-client/src/main/java/ol/Map.java
+++ b/gwt-ol3-client/src/main/java/ol/Map.java
@@ -16,7 +16,7 @@
 package ol;
 
 import com.google.gwt.dom.client.Element;
-import com.google.web.bindery.event.shared.HandlerRegistration;
+import com.google.gwt.event.shared.HandlerRegistration;
 
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;

--- a/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
+++ b/gwt-ol3-client/src/main/java/ol/event/OLHandlerRegistration.java
@@ -47,7 +47,7 @@ public class OLHandlerRegistration implements HandlerRegistration {
      * (non-Javadoc)
      * 
      * @see
-     * com.google.web.bindery.event.shared.HandlerRegistration#removeHandler()
+     * com.google.gwt.event.shared.HandlerRegistration#removeHandler()
      */
     @Override
     public void removeHandler() {

--- a/gwt-ol3-client/src/main/java/ol/interaction/DragBox.java
+++ b/gwt-ol3-client/src/main/java/ol/interaction/DragBox.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package ol.interaction;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
+import com.google.gwt.event.shared.HandlerRegistration;
 
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;

--- a/gwt-ol3-client/src/main/java/ol/source/Tile.java
+++ b/gwt-ol3-client/src/main/java/ol/source/Tile.java
@@ -15,7 +15,7 @@
  *******************************************************************************/
 package ol.source;
 
-import com.google.web.bindery.event.shared.HandlerRegistration;
+import com.google.gwt.event.shared.HandlerRegistration;
 
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsProperty;


### PR DESCRIPTION
The legacy implementation is `com.google.web.bindery.event.shared.HandlerRegistration`.
The new implementation is `com.google.event.shared.HandlerRegistration`.
There is even a wrapper to turn the old implementation to the new one: `com.google.gwt.event.shared.LegacyHandlerWrapper`
(see also http://www.gwtproject.org/javadoc/latest/com/google/gwt/event/shared/LegacyHandlerWrapper.html).

The legacy interface was introduced by commit aba651a873dbbaf81eca5271efb5f0df0a244ec5 as in [OLUtil.java](https://github.com/TDesjardins/gwt-ol3/blob/master/gwt-ol3-client/src/main/java/ol/OLUtil.java#L22) is still the correct/new one.