### PR TITLE
Fix double-click handler coordinate

### DIFF
--- a/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/MapEventsExample.java
+++ b/gwt-ol3-demo/src/main/java/com/github/tdesjardins/ol3/demo/client/example/MapEventsExample.java
@@ -97,7 +97,8 @@ public class MapEventsExample implements Example {
         map.addInteraction(new MouseWheelZoom());
 
         // add event handlers
-        map.addDoubleClickListener(evt -> Window.alert("double click at " + evt.getCoordinate().getX() + ", " + evt.getCoordinate().getX()));
+        map.addDoubleClickListener(evt ->
+                Window.alert("double click at " + evt.getCoordinate().getX() + ", " + evt.getCoordinate().getY()));
 
         map.addMapZoomListener(evt -> GWT.log("onZoom"));
 


### PR DESCRIPTION
## Summary
- correct Y coordinate in the MapEventsExample double-click handler

## Testing
- `mvn -q test` *(fails: `mvn` not found)*